### PR TITLE
Empty check fix

### DIFF
--- a/idea-plugin/src/main/java/org/jetbrains/bunches/idea/util/BunchFileUtils.kt
+++ b/idea-plugin/src/main/java/org/jetbrains/bunches/idea/util/BunchFileUtils.kt
@@ -89,7 +89,7 @@ object BunchFileUtils {
         bunchFileCache[bunchFile] = ExtensionsData(timeStamp, extensions)
 
         val invalidFiles = bunchFileCache.keys.filter { !it.isValid }
-        if (invalidFiles.isEmpty()) {
+        if (invalidFiles.isNotEmpty()) {
             for (invalidFile in invalidFiles) {
                 bunchFileCache.remove(invalidFile)
             }


### PR DESCRIPTION
If we use `for` loop, we want to check if collection is NOT empty before